### PR TITLE
♻️ Simplify decryption.

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func main() {
 
 	cmd := command.Build(framework.SimpleProcessor{Filter: p, Config: functionConfig}, command.StandaloneDisabled, false)
 	command.AddGenerateDockerfile(cmd)
-	cmd.Version = "v0.1.3" // <---VERSION--->
+	cmd.Version = "v0.1.4" // <---VERSION--->
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/tests/kustomization.yaml
+++ b/tests/kustomization.yaml
@@ -2,7 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./secret.yaml
+  - ./secret2.enc.yaml
+
+generators:
+  - sops-generator.yaml
 
 transformers:
-  - sops-generator.yaml
+  - sops-transformer.yaml

--- a/tests/secret2.yaml
+++ b/tests/secret2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  name: private-repo-two
+  namespace: argocd
+stringData:
+  password: my-password-two
+  type: git
+  url: https://github.com/argoproj/private-repo
+  username: my-username-two

--- a/tests/sops-transformer.yaml
+++ b/tests/sops-transformer.yaml
@@ -1,5 +1,5 @@
 apiVersion: kaweezle
-kind: SecretsGenerator
+kind: SecretsTransformer
 metadata:
   name: whatever
   annotations:
@@ -7,6 +7,3 @@ metadata:
     config.kubernetes.io/function: |
       exec:
         path: ../krmfnsops
-spec:
-  files:
-    - ./secret.enc.yaml

--- a/tests/test_krmsops.sh
+++ b/tests/test_krmsops.sh
@@ -17,7 +17,12 @@ export SOPS_AGE_KEY_FILE="$(pwd)/key.txt"
 export SOPS_AGE_RECIPIENTS=$(grep public key.txt | cut -d' ' -f 4)
 echo "Encrypting secret.yaml -> secret.enc.yaml with key.txt..."
 sops -e secret.yaml > secret.enc.yaml
+echo "Encrypting secret2.yaml -> secret2.enc.yaml with key.txt..."
+sops -e secret2.yaml > secret2.enc.yaml
 echo "Running kustomize with transformer..."
 kustomize build . --enable-alpha-plugins --enable-exec > secret.dec.yaml
-diff <(yq eval -P secret.yaml) <(yq eval -P secret.dec.yaml)
+cat secret.yaml > expected.dec.yaml
+echo "---" >> expected.dec.yaml
+cat secret2.yaml >> expected.dec.yaml
+diff <(yq eval -P expected.dec.yaml) <(yq eval -P secret.dec.yaml)
 echo "Secret has been decoded ok 🎉"


### PR DESCRIPTION
Looking at the SOPS help, we find that we can ignore the Mac
verification. The function used is `DecryptTree`. Replaced the old method
with the use of this function.

Also added a test for the transformer mode of operation.